### PR TITLE
CircleCI - caching fix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,13 +13,20 @@ jobs:
     working_directory: ~/repo
     steps:
       - checkout
-
+      - run:
+          sudo chown -R circleci:circleci /usr/local/bin
+      - run:
+          sudo chown -R circleci:circleci /usr/local/lib/python3.7/site-packages
+      - restore_cache:
+          key: installed-packages-{{ checksum "requirements.txt" }}
       - run:
           name: install dependencies
           command: |
             python3 -m venv venv
             . venv/bin/activate
             pip install -r requirements.txt
+
+            key: installed-packages-{{ checksum "requirements.txt" }}
 
       - run:
           name: Run unit tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,8 +17,12 @@ jobs:
           sudo chown -R circleci:circleci /usr/local/bin
       - run:
           sudo chown -R circleci:circleci /usr/local/lib/python3.7/site-packages
+      - run:
+          sudo chown -R circleci:circleci ./venv
       - restore_cache:
-          key: installed-packages-{{ checksum "requirements.txt" }}
+          keys:
+            - v1-dependencies-{{ checksum "requirements.txt" }}
+            - v1-dependencies-
       - run:
           name: install dependencies
           command: |
@@ -26,7 +30,13 @@ jobs:
             . venv/bin/activate
             pip install -r requirements.txt
 
-            key: installed-packages-{{ checksum "requirements.txt" }}
+      - save_cache:
+          paths:
+            - ./venv
+            - /usr/local/bin
+            - /usr/local/lib/python3.7/site-packages
+
+          key: v1-dependencies-{{ checksum "requirements.txt" }}
 
       - run:
           name: Run unit tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,8 +17,6 @@ jobs:
           sudo chown -R circleci:circleci /usr/local/bin
       - run:
           sudo chown -R circleci:circleci /usr/local/lib/python3.7/site-packages
-      - run:
-          sudo chown -R circleci:circleci ./venv
       - restore_cache:
           keys:
             - v1-dependencies-{{ checksum "requirements.txt" }}


### PR DESCRIPTION
The problem with the previous caching approach was that CircleCI was unable to restore the cache since it didn't have permissions on some Python specific folders - the weird part was it was working before. Anyway, this PR adds those permissions and restores the caching steps.